### PR TITLE
context: escape the member value

### DIFF
--- a/context.go
+++ b/context.go
@@ -2,6 +2,7 @@ package zlog
 
 import (
 	"context"
+	"net/url"
 
 	"go.opentelemetry.io/otel/baggage"
 )
@@ -16,7 +17,7 @@ func ContextWithValues(ctx context.Context, pairs ...string) context.Context {
 	pairs = pairs[:len(pairs)-len(pairs)%2]
 	for i := 0; i < len(pairs); i = i + 2 {
 		k, v := pairs[i], pairs[i+1]
-		m, err := baggage.NewMember(k, v)
+		m, err := baggage.NewMember(k, url.PathEscape(v))
 		if err != nil {
 			Warn(ctx).
 				Err(err).

--- a/zlog_test.go
+++ b/zlog_test.go
@@ -70,6 +70,15 @@ func TestContext(t *testing.T) {
 	Log(ctx).Msg("message")
 }
 
+func TestContextWithBadChars(t *testing.T) {
+	ctx := Test(context.Background(), t)
+	ctx = ContextWithValues(ctx,
+		"key1", "no bad news?#")
+	Log(ctx).Msg("message")
+	// Output:
+	// {"key":"no%20bad%20news%3F%23","message":"message"}
+}
+
 func Example() {
 	l := zerolog.New(os.Stdout)
 	Set(&l)


### PR DESCRIPTION
When passing values with spaces or special characters
the otel/baggage will reject it due to the standard
constraints: https://www.w3.org/TR/baggage/#value

Signed-off-by: crozzy <joseph.crosland@gmail.com>