### PR TITLE
context: Replace specific illegal chars

### DIFF
--- a/context.go
+++ b/context.go
@@ -2,7 +2,7 @@ package zlog
 
 import (
 	"context"
-	"net/url"
+	"strings"
 
 	"go.opentelemetry.io/otel/baggage"
 )
@@ -17,7 +17,9 @@ func ContextWithValues(ctx context.Context, pairs ...string) context.Context {
 	pairs = pairs[:len(pairs)-len(pairs)%2]
 	for i := 0; i < len(pairs); i = i + 2 {
 		k, v := pairs[i], pairs[i+1]
-		m, err := baggage.NewMember(k, url.PathEscape(v))
+		r := strings.NewReplacer(" ", "%20", `"`, "%22", ",", "%2C", ";", "%3B", `\`, "%5C")
+		v = r.Replace(v)
+		m, err := baggage.NewMember(k, v)
 		if err != nil {
 			Warn(ctx).
 				Err(err).

--- a/zlog_test.go
+++ b/zlog_test.go
@@ -10,14 +10,14 @@ import (
 )
 
 func TestTestHarness(t *testing.T) {
-	ctx := Test(nil, t)
+	ctx := Test(context.TODO(), t)
 	t.Log("🖳")
 	Log(ctx).Msg("🖳")
 	Log(ctx).Msg("🆒")
 }
 
 func TestDeduplication(t *testing.T) {
-	ctx := Test(nil, t)
+	ctx := Test(context.TODO(), t)
 	t.Log("make sure keys aren't repeated")
 	m, _ := baggage.NewMember("x", "5")
 	b, _ := baggage.FromContext(ctx).SetMember(m)
@@ -32,7 +32,7 @@ func TestDeduplication(t *testing.T) {
 }
 
 func TestSub(t *testing.T) {
-	ctx := Test(nil, t)
+	ctx := Test(context.TODO(), t)
 	t.Log("make sure subtests are intelligible")
 	m, _ := baggage.NewMember("outer", "test")
 	b, _ := baggage.FromContext(ctx).SetMember(m)
@@ -73,10 +73,12 @@ func TestContext(t *testing.T) {
 func TestContextWithBadChars(t *testing.T) {
 	ctx := Test(context.Background(), t)
 	ctx = ContextWithValues(ctx,
-		"key1", "no bad news?#")
+		"key1", `no bad news",;\`,
+		"key2", "all/fine.here")
 	Log(ctx).Msg("message")
 	// Output:
-	// {"key":"no%20bad%20news%3F%23","message":"message"}
+	// {"key1":"no%20bad%20news%22%2C%3B%5C","key2":"all/fine.here","message":"message"}
+	t.Error("bl")
 }
 
 func Example() {


### PR DESCRIPTION
The otel library identifies a certain set of chars
that cannot be added as a value to member, this is to
allow them to be set as http headers. This change check
and replaces those chars with their hex counterparts.

Signed-off-by: crozzy <joseph.crosland@gmail.com>