### PR TITLE
zlog: also escape `%`

### DIFF
--- a/context.go
+++ b/context.go
@@ -7,6 +7,15 @@ import (
 	"go.opentelemetry.io/otel/baggage"
 )
 
+var esc = strings.NewReplacer(
+	"%", "%25",
+	" ", "%20",
+	`"`, "%22",
+	",", "%2C",
+	";", "%3B",
+	`\`, "%5C",
+)
+
 // ContextWithValues is a helper for the go.opentelemetry.io/otel/baggage v1
 // API. It takes pairs of strings and adds them to the Context via the baggage
 // package.
@@ -17,8 +26,7 @@ func ContextWithValues(ctx context.Context, pairs ...string) context.Context {
 	pairs = pairs[:len(pairs)-len(pairs)%2]
 	for i := 0; i < len(pairs); i = i + 2 {
 		k, v := pairs[i], pairs[i+1]
-		r := strings.NewReplacer(" ", "%20", `"`, "%22", ",", "%2C", ";", "%3B", `\`, "%5C")
-		v = r.Replace(v)
+		v = esc.Replace(v)
 		m, err := baggage.NewMember(k, v)
 		if err != nil {
 			Warn(ctx).


### PR DESCRIPTION
Found when some yahoo used `%` in a path.